### PR TITLE
Add width-parameterized ReLU module and its test bench

### DIFF
--- a/ReLU/relu.v
+++ b/ReLU/relu.v
@@ -1,0 +1,22 @@
+/* A collection of hardware modules implementing the Rectified Linear Unit
+    (ReLU) function, common in artificial neural networks and deep learning.
+*/
+
+
+/* A width-parameterized implementation. Doesn't matter if input is 16-bit, 32-bit,
+    etc., as long as WIDTH parameter is correctly set.
+    By default, uses the IEEE 754 floating point standards, with the leftmost
+    bit (index WIDTH - 1) being the sign bit.
+*/
+module relu_width_parameterized #(
+    parameter WIDTH = 16
+) (
+    input [WIDTH-1:0] num,
+    output reg[WIDTH-1:0] relu_num
+);
+
+always @(num) begin
+    relu_num = {num[WIDTH-1:WIDTH-1], ({(WIDTH-1){~num[WIDTH-1]}} & num[WIDTH-2:0])};
+end
+
+endmodule

--- a/ReLU/relu_test_bench.v
+++ b/ReLU/relu_test_bench.v
@@ -1,0 +1,64 @@
+/* A collection of test benches for testing ReLU modules. */
+
+
+/* Tests the width-parameterized ReLU module.
+
+    Once the module under testing is known to be working, 
+    propagation_delay can be lowered to find the minimum number of clock cycles
+    needed for the module under testing to succeed.
+*/
+module relu_test_bench #(
+    parameter WIDTH = 64,
+    parameter propagation_delay = 1
+) ();
+
+reg[WIDTH-1:0] input_num;
+wire[WIDTH-1:0] output_num;
+wire equal_nums;
+
+relu_width_parameterized #(WIDTH) relu_module (
+    .num        (input_num),
+    .relu_num   (output_num)
+);
+
+
+assign equal_nums = input_num == output_num;
+
+initial begin
+    // Can't use $monitor because of use of $bitstoreal() to print floating point values
+    input_num = $realtobits(1.0);
+    #(propagation_delay)
+    log_result(input_num, output_num, equal_nums);
+
+    input_num = $realtobits(0.1);
+    #(propagation_delay)
+    log_result(input_num, output_num, equal_nums);
+
+    input_num = $realtobits(0.0);
+    #(propagation_delay)
+    log_result(input_num, output_num, equal_nums);
+
+    input_num = $realtobits(-0.1);
+    #(propagation_delay)
+    log_result(input_num, output_num, equal_nums);
+
+    input_num = $realtobits(-1.0);
+    #(propagation_delay)
+    log_result(input_num, output_num, equal_nums);
+
+    $finish;
+end
+
+
+
+// Prints values of input and output
+// ReLU succeeds when input == output for input >= 0,
+// or output == 0.0 for input < 0.0
+task log_result(input[WIDTH-1:0] input_num, input[WIDTH-1:0] output_num, input equal_nums);
+    if (($bitstoreal(input_num) >= 0.0 && equal_nums) || ($bitstoreal(output_num) == 0.0 && $bitstoreal(input_num) < 0.0))
+        $display("Success. input = %f, output = %f", $bitstoreal(input_num), $bitstoreal(output_num));
+    else
+        $display("FAILURE. input = %f, output = %f", $bitstoreal(input_num), $bitstoreal(output_num));
+endtask
+
+endmodule


### PR DESCRIPTION
Add width-parameterized ReLU module and its test bench.

Given an input floating point number, ReLU returns the input if the input is positive, otherwise it returns 0.

### Testing

Run `./test.sh ReLU/` or `iverilog -o check ReLU/relu.v ReLU/relu_test_bench.v && vvp check`. Results should be as follows:

```
Success. input = 1.000000, output = 1.000000
Success. input = 0.100000, output = 0.100000
Success. input = 0.000000, output = 0.000000
Success. input = -0.100000, output = -0.000000
Success. input = -1.000000, output = -0.000000
```
